### PR TITLE
[Threaded Messaging] Inline Messaging Support + Tweaks

### DIFF
--- a/Source/SLKTextInputbar.h
+++ b/Source/SLKTextInputbar.h
@@ -64,6 +64,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) CGFloat appropriateHeight;
 
 
+- (void)slk_updateConstraintConstants;
+
 #pragma mark - Initialization
 ///------------------------------------------------
 /// @name Initialization
@@ -97,6 +99,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** The accessory view's maximum height. Default is 38 pts. */
 @property (nonatomic, assign) CGFloat editorContentViewHeight;
+
+/** The content views height */
+@property (nonatomic, strong, readonly) NSLayoutConstraint *contentViewHC;
 
 /** A Boolean value indicating whether the control is in edit mode. */
 @property (nonatomic, getter = isEditing) BOOL editing;

--- a/Source/SLKTextInputbar.m
+++ b/Source/SLKTextInputbar.m
@@ -663,10 +663,9 @@ NSString * const SLKTextInputbarDidMoveNotification =   @"SLKTextInputbarDidMove
     [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-(>=0)-[leftButton(0)]-(0@750)-|" options:0 metrics:metrics views:views]];
     [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-(>=0)-[rightButton]-(<=0)-|" options:0 metrics:metrics views:views]];
     [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-(left@250)-[charCountLabel(<=50@1000)]-(right@750)-|" options:0 metrics:metrics views:views]];
-    [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-0-[editorContentView(0)]-(<=top)-[textView(0@999)]-(0)-|" options:0 metrics:metrics views:views]];
+    [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|[contentView(0)]-0-[editorContentView(0)]-(<=top)-[textView(0@999)]-(0)-|" options:0 metrics:metrics views:views]];
     [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[editorContentView]|" options:0 metrics:metrics views:views]];
     [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[contentView]|" options:0 metrics:metrics views:views]];
-    [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:[contentView(0)]|" options:0 metrics:metrics views:views]];
 
     self.textViewBottomMarginC = [self slk_constraintForAttribute:NSLayoutAttributeBottom firstItem:self secondItem:self.textView];
     self.editorContentViewHC = [self slk_constraintForAttribute:NSLayoutAttributeHeight firstItem:self.editorContentView secondItem:nil];

--- a/Source/SLKTextViewController.h
+++ b/Source/SLKTextViewController.h
@@ -122,6 +122,7 @@ NS_CLASS_AVAILABLE_IOS(7_0) @interface SLKTextViewController : UIViewController 
 @property (nonatomic, readonly) UIButton *leftButton;
 @property (nonatomic, readonly) UIButton *rightButton;
 
+- (void)slk_updateViewConstraints;
 
 #pragma mark - Initialization
 ///------------------------------------------------

--- a/Source/SLKTextViewController.m
+++ b/Source/SLKTextViewController.m
@@ -1153,7 +1153,7 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
 {
     NSArray *actions = [self.rightButton actionsForTarget:self forControlEvent:UIControlEventTouchUpInside];
     
-    if (actions.count > 0 && [self canPressRightButton]) {
+    if (actions.count > 0) {
         [self.rightButton sendActionsForControlEvents:UIControlEventTouchUpInside];
     }
 }
@@ -2213,6 +2213,7 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
             _keyboardHeightBeforeDragging = self.keyboardHC.constant;
         }
     }
+    [self dismissKeyboard:YES];
 }
 
 


### PR DESCRIPTION
## Purpose
We need to modify the internals of the library to allow for us to do the following things:
- Recalculate constraints and layout explicitly
- Move the content view to the top of the inputTextBar
- Dismiss keyboard upon scroll

## Solution
- Do it

## Test Cases
- Verify everything works as intended in BW land
