### PR TITLE
Release/1.9.8-bw

### DIFF
--- a/SlackTextViewController.podspec
+++ b/SlackTextViewController.podspec
@@ -1,4 +1,4 @@
-@version = "1.9.6"
+@version = "1.9.8-bw"
 
 Pod::Spec.new do |s|
   s.name         		= "SlackTextViewController"
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.screenshots     = "https://github.com/slackhq/SlackTextViewController/raw/master/Screenshots/slacktextviewcontroller_demo.gif"
   s.license         = { :type => 'MIT', :file => 'LICENSE' }
   s.author       		= { "Slack Technologies, Inc." => "ios-team@slack-corp.com" }
-  s.source          = { :git => "https://github.com/slackhq/SlackTextViewController.git", :tag => "v#{s.version}" }
+  s.source          = { :git => "https://github.com/brightwheel/SlackTextViewController.git", :tag => "v#{s.version}" }
 
   s.frameworks    	= 'CoreGraphics', 'UIKit'
   s.platform     		= :ios, "7.0"

--- a/SlackTextViewController/SlackTextViewController/Info.plist
+++ b/SlackTextViewController/SlackTextViewController/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.9.7-b</string>
+	<string>1.9.8-bw</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Source/SLKTextViewController.m
+++ b/Source/SLKTextViewController.m
@@ -2213,7 +2213,6 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
             _keyboardHeightBeforeDragging = self.keyboardHC.constant;
         }
     }
-    [self dismissKeyboard:YES];
 }
 
 


### PR DESCRIPTION
## Purpose
Ensure we don't dismiss the keyboard when the user scrolls, as this implicitly happens when the return key is pressed

## Solution
- Do it
